### PR TITLE
Handle custom palette row and export names

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Go to directory and run go get, go build, and run CLImgExport.<br>
 Alt: Go to dir, go run .<br>
 <br>
 Note:<br>
-The program will create a directory called out, and will save 7000+ PNG images from the CL_Images file.<br>
-If found in the images file, the image name will be included as well (id-0123-item name.png).<br>
+The program will create a directory called out and will save 7000+ PNG images from the CL_Images file using the image ID as the filename.<br>
+Names and related ID data are written to out/names.csv.<br>
 This software is unlicence (completely free).<br>
 <br>
 This project is based on: https://github.com/mpolney/clext/<br>

--- a/struct.go
+++ b/struct.go
@@ -7,6 +7,7 @@ const TYPE_NAME = 0x43496d34     //Name
 const TYPE_MYSTERY1 = 0x4c697431 //No idea
 const TYPE_MYSTERY2 = 0x56657273 //No idea
 const TYPE_MYSTERY3 = 0x4c617933 //No idea
+const pictDefCustomColors = 0x2000
 
 type dataLocation struct {
 	offset    uint32 //Location in the file
@@ -18,4 +19,7 @@ type dataLocation struct {
 	name       string
 	imageID    uint32
 	colorID    uint32
+	version    uint32
+	checksum   uint32
+	flags      uint32
 }


### PR DESCRIPTION
## Summary
- parse IDREF flags to remove custom palette row from images
- export images using only their ID as filename
- record image names and metadata into `out/names.csv`

## Testing
- `go fmt ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6898329ab830832a9dd68a95c107526d