### PR TITLE
Support optional use of image palettes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Download golang 1.20 or higher<br>
 Copy CL_Images into the directory with the code<br>
 Go to directory and run go get, go build, and run CLImgExport.<br>
 Alt: Go to dir, go run .<br>
+Optional: Use -usePalette to apply palettes stored inside the image data when available.<br>
 <br>
 Note:<br>
 The program will create a directory called out and will save 7000+ PNG images from the CL_Images file using the image ID as the filename.<br>


### PR DESCRIPTION
## Summary
- add `-usePalette` flag to enable palette data embedded in BIT2 images
- implement palette extraction from custom color row when the flag is set
- document `-usePalette` usage in README

## Testing
- `go build ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689834fb55c0832a8786d2a5402b0c56