### PR TITLE
chore: add Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Adds weekly Dependabot checks for Go modules and GitHub Actions.\n\nThis enables reviewable dependency-update pull requests; it does not update application dependencies directly.